### PR TITLE
HP-2710: Add Dockerfile for Playwright 1.56.1 setup, update Node vers…

### DIFF
--- a/playwright/1.56.1/Dockerfile
+++ b/playwright/1.56.1/Dockerfile
@@ -1,0 +1,33 @@
+FROM node:24-bullseye
+
+# Tells apt and dpkg to skip interactive prompts.
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install system dependencies required by Playwright
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    libnss3 \
+    libxss1 \
+    libasound2 \
+    libx11-xcb1 \
+    libgtk-3-0 && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# === BAKE BROWSERS INTO IMAGE ===
+# 1. Change browser cache directory from ~/.cache/ms-playwright
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+
+# 2. Create directory and make it world-accessible
+RUN mkdir -p /ms-playwright && chmod -R 777 /ms-playwright
+
+# Install Playwright 1.43.0 and its browsers
+RUN npm install -g playwright@1.56.1 && \
+    npx playwright install --with-deps && \
+    rm -rf /var/lib/apt/lists/*
+
+# Set default working directory
+WORKDIR /app
+
+# Verify installation
+RUN playwright --version && ls -l /ms-playwright

--- a/playwright/1.56.1/Dockerfile
+++ b/playwright/1.56.1/Dockerfile
@@ -21,7 +21,7 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 # 2. Create directory and make it world-accessible
 RUN mkdir -p /ms-playwright && chmod -R 777 /ms-playwright
 
-# Install Playwright 1.43.0 and its browsers
+# Install Playwright 1.56.1 and its browsers
 RUN npm install -g playwright@1.56.1 && \
     npx playwright install --with-deps && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
…ion up to 24

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a Docker image with Node.js 24 and Playwright 1.56.1 for browser automation and testing.
  * Pre-installs required system dependencies and browser binaries, configures the runtime environment, and includes a basic installation validation step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->